### PR TITLE
Add rule-based arrow detection baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# Arrow detection reference solution
+
+This repository contains a light-weight, rule-based detector that localises four
+square-ish arrows in each training image and predicts their directions using
+only classical computer vision operations. The detector is purposely
+interpretable and relies on the dataset's structural constraints:
+
+* Exactly four arrows appear per image and share a similar vertical band.
+* Arrows have a near-square footprint (roughly 40–70 px in each dimension).
+* Each arrow features a prominent triangular tip, which allows us to infer
+  orientation from geometry alone.
+
+## Project layout
+
+```
+arrow-detection/
+├── src/arrow_detection/        # Python package with the detector implementation
+├── scripts/                    # CLI entry points for inference and evaluation
+└── training-proc/              # Provided dataset of processed training images
+```
+
+## Installation
+
+The code depends only on NumPy and OpenCV. Install them into your preferred
+virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install numpy opencv-python-headless
+```
+
+## Running the detector on a single image
+
+```bash
+python scripts/detect_arrows.py training-proc/08190218_processed.png \
+  --output outputs/08190218_annotated.png \
+  --json outputs/08190218_detections.json
+```
+
+The script prints a JSON payload of the detections (bounding boxes, predicted
+orientation, and a simple confidence heuristic). When `--output` is provided the
+image is saved with visual annotations.
+
+## Evaluating against the provided labels
+
+```bash
+python scripts/evaluate_dataset.py --limit 25
+```
+
+The optional `--limit` flag is helpful for quick sanity checks. Remove it to run
+on the full dataset. Evaluation reports the proportion of images whose predicted
+four-character direction string matches the label exactly and enumerates the
+first few mismatches for inspection.
+
+## How it works
+
+1. **Pre-processing** – Images are blurred slightly before applying a Canny edge
+   detector followed by morphological closing/dilation to obtain clean arrow
+   blobs.
+2. **Candidate selection** – Contours are filtered by area and aspect ratio so
+   that only near-square shapes remain.
+3. **Direction estimation** – For each candidate contour we compute its centroid
+   and locate the farthest contour point, which reliably corresponds to the
+   arrow tip. Comparing the tip vector's horizontal and vertical components
+   reveals the arrow orientation.
+4. **Post-processing** – Detections are sorted left-to-right and truncated to the
+   expected four arrows per image.
+
+This deterministic baseline is intentionally simple but establishes a reference
+point for more advanced learning-based approaches.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+opencv-python-headless

--- a/scripts/detect_arrows.py
+++ b/scripts/detect_arrows.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""CLI utility for running the rule-based arrow detector on an image."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+import cv2
+
+from arrow_detection import ArrowDetector
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("image", type=Path, help="Path to the image to analyse")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path where an annotated image should be written",
+    )
+    parser.add_argument(
+        "--json",
+        type=Path,
+        help="Optional path where detections should be serialised as JSON",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if not args.image.exists():
+        raise SystemExit(f"Image {args.image} does not exist")
+
+    image = cv2.imread(str(args.image))
+    if image is None:
+        raise SystemExit(f"Failed to load image {args.image}")
+
+    detector = ArrowDetector()
+    detections = detector.detect(image)
+
+    if args.output:
+        annotated = detector.annotate(image, detections)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        cv2.imwrite(str(args.output), annotated)
+
+    serialised: List[dict] = [det.as_dict() for det in detections]
+    json_payload = json.dumps(serialised, indent=2)
+
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json_payload)
+    else:
+        print(json_payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate_dataset.py
+++ b/scripts/evaluate_dataset.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Evaluate the rule-based detector against the supplied label file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import cv2
+
+from arrow_detection import ArrowDetector
+
+
+@dataclass
+class EvaluationResult:
+    image_path: Path
+    expected: str
+    predicted: str
+    detections: List[dict]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--images",
+        type=Path,
+        default=Path("training-proc"),
+        help="Directory containing processed training PNG files",
+    )
+    parser.add_argument(
+        "--labels",
+        type=Path,
+        default=Path("training-proc/labels.json"),
+        help="Path to the JSON file containing labels",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional number of images to evaluate (useful for smoke tests)",
+    )
+    return parser
+
+
+def _iter_labelled_images(images_dir: Path, label_path: Path) -> Iterable[EvaluationResult]:
+    data = json.loads(label_path.read_text())
+    detector = ArrowDetector()
+    for idx, entry in enumerate(data):
+        prefix = entry["image_prefix"]
+        expected = entry["labels"]
+        image_path = images_dir / f"{prefix}_processed.png"
+        image = cv2.imread(str(image_path))
+        if image is None:
+            raise FileNotFoundError(f"Failed to read {image_path}")
+        detections = detector.detect(image)
+        predicted = "".join(det.direction for det in detections)
+        yield EvaluationResult(
+            image_path=image_path,
+            expected=expected,
+            predicted=predicted,
+            detections=[det.as_dict() for det in detections],
+        )
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    results = []
+    for idx, result in enumerate(_iter_labelled_images(args.images, args.labels)):
+        results.append(result)
+        if args.limit is not None and idx + 1 >= args.limit:
+            break
+
+    total = len(results)
+    exact_matches = sum(1 for res in results if res.expected == res.predicted)
+    print(f"Processed {total} images")
+    print(f"Exact matches: {exact_matches}/{total} ({exact_matches / max(1, total):.2%})")
+
+    mismatches = [res for res in results if res.expected != res.predicted]
+    if mismatches:
+        print("\nFirst 5 mismatches:")
+        for res in mismatches[:5]:
+            print(f"- {res.image_path.name}: expected {res.expected}, predicted {res.predicted}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/arrow_detection/__init__.py
+++ b/src/arrow_detection/__init__.py
@@ -1,0 +1,5 @@
+"""Arrow detection package."""
+
+from .detector import ArrowDetector, ArrowDetection
+
+__all__ = ["ArrowDetector", "ArrowDetection"]

--- a/src/arrow_detection/detector.py
+++ b/src/arrow_detection/detector.py
@@ -1,0 +1,137 @@
+"""Rule-based arrow detection leveraging contour geometry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+import cv2
+import numpy as np
+
+
+@dataclass
+class ArrowDetection:
+    """Container representing a single detection result."""
+
+    bounding_box: Tuple[int, int, int, int]
+    direction: str
+    confidence: float
+
+    def as_dict(self) -> dict:
+        """Return a JSON-serialisable representation of the detection."""
+
+        x, y, w, h = self.bounding_box
+        return {
+            "x": int(x),
+            "y": int(y),
+            "width": int(w),
+            "height": int(h),
+            "direction": self.direction,
+            "confidence": float(self.confidence),
+        }
+
+
+class ArrowDetector:
+    """Detect square-ish arrows with a pronounced tip using OpenCV primitives."""
+
+    def __init__(
+        self,
+        min_area: float = 1400.0,
+        max_area: float = 7200.0,
+        aspect_ratio_range: Tuple[float, float] = (0.65, 1.55),
+        canny_thresholds: Tuple[int, int] = (40, 140),
+    ) -> None:
+        self.min_area = min_area
+        self.max_area = max_area
+        self.aspect_ratio_range = aspect_ratio_range
+        self.canny_thresholds = canny_thresholds
+
+    def detect(self, image: np.ndarray) -> List[ArrowDetection]:
+        """Detect arrows in ``image``.
+
+        Parameters
+        ----------
+        image:
+            A ``numpy.ndarray`` in BGR format (as returned by :func:`cv2.imread`).
+
+        Returns
+        -------
+        list of :class:`ArrowDetection`
+            A list of detections sorted from left to right.
+        """
+
+        processed = self._preprocess(image)
+        contours = self._find_candidate_contours(processed)
+        detections = [self._contour_to_detection(image, contour) for contour in contours]
+        detections = [d for d in detections if d is not None]
+        detections.sort(key=lambda det: det.bounding_box[0])
+        return detections[:4]
+
+    def annotate(self, image: np.ndarray, detections: Sequence[ArrowDetection]) -> np.ndarray:
+        """Return a copy of ``image`` with detection annotations drawn."""
+
+        output = image.copy()
+        for detection in detections:
+            x, y, w, h = detection.bounding_box
+            cv2.rectangle(output, (x, y), (x + w, y + h), (0, 255, 0), 2)
+            label = f"{detection.direction}:{detection.confidence:.2f}"
+            cv2.putText(output, label, (x, y - 5), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 255), 1)
+        return output
+
+    def _preprocess(self, image: np.ndarray) -> np.ndarray:
+        blurred = cv2.GaussianBlur(image, (5, 5), 0)
+        gray = cv2.cvtColor(blurred, cv2.COLOR_BGR2GRAY)
+        edges = cv2.Canny(gray, *self.canny_thresholds)
+        kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5))
+        closed = cv2.morphologyEx(edges, cv2.MORPH_CLOSE, kernel, iterations=2)
+        filled = cv2.dilate(closed, kernel, iterations=1)
+        return filled
+
+    def _find_candidate_contours(self, mask: np.ndarray) -> List[np.ndarray]:
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        filtered: List[np.ndarray] = []
+        for contour in contours:
+            area = cv2.contourArea(contour)
+            if area < self.min_area or area > self.max_area:
+                continue
+            x, y, w, h = cv2.boundingRect(contour)
+            aspect_ratio = w / float(h)
+            if not (self.aspect_ratio_range[0] <= aspect_ratio <= self.aspect_ratio_range[1]):
+                continue
+            filtered.append(contour)
+        return filtered
+
+    def _contour_to_detection(self, image: np.ndarray, contour: np.ndarray) -> ArrowDetection | None:
+        moments = cv2.moments(contour)
+        if moments["m00"] == 0:
+            return None
+        cx = moments["m10"] / moments["m00"]
+        cy = moments["m01"] / moments["m00"]
+
+        points = contour.reshape(-1, 2)
+        fx, fy = max(points, key=lambda pt: (pt[0] - cx) ** 2 + (pt[1] - cy) ** 2)
+        dx = fx - cx
+        dy = fy - cy
+
+        direction: str
+        if abs(dx) >= abs(dy):
+            direction = "d" if dx > 0 else "a"
+        else:
+            direction = "s" if dy > 0 else "w"
+
+        dominance = max(abs(dx), abs(dy))
+        orthogonal = max(1e-5, min(abs(dx), abs(dy)))
+        confidence = float(min(1.0, dominance / orthogonal))
+
+        x, y, w, h = cv2.boundingRect(contour)
+        return ArrowDetection((int(x), int(y), int(w), int(h)), direction, confidence)
+
+
+def detect_from_path(image_path: str) -> List[ArrowDetection]:
+    """Convenience function for quick experiments from an image path."""
+
+    image = cv2.imread(str(image_path))
+    if image is None:
+        raise FileNotFoundError(f"Unable to read image at {image_path}")
+    detector = ArrowDetector()
+    return detector.detect(image)


### PR DESCRIPTION
## Summary
- implement a contour-driven `ArrowDetector` that predicts bounding boxes and arrow directions
- add command line tools for single-image inference and dataset evaluation
- document setup steps and required dependencies in a new README

## Testing
- python scripts/detect_arrows.py training-proc/08190218_processed.png *(fails: ModuleNotFoundError: No module named 'cv2' – dependency needs to be installed)*

------
https://chatgpt.com/codex/tasks/task_b_68e43e5612b4832eb54d55e8443fc913